### PR TITLE
Fire afterInsert when item from array has been inserted

### DIFF
--- a/jquery-loadTemplate/jquery.loadTemplate-1.5.0.js
+++ b/jquery-loadTemplate/jquery.loadTemplate-1.5.0.js
@@ -2,7 +2,8 @@
     "use strict";
     var templates = {},
         queue = {},
-        formatters = {};
+        formatters = {},
+        isArray;
 
     function loadTemplate(template, data, options) {
         var $that = this,
@@ -39,6 +40,7 @@
         }, options);
 
         if ($.type(data) === "array") {
+            isArray = true;
             return processArray.call(this, template, data, settings);
         }
 
@@ -97,12 +99,16 @@
             settings,
             {
                 async: false,
-                complete: function () {
+                complete: function (data) {
                     if (this.html) {
+                        var insertedElement;
                         if (doPrepend) {
-                            $that.prepend(this.html());
+                            insertedElement = $(this.html()).prependTo($that);
                         } else {
-                            $that.append(this.html());
+                            insertedElement = $(this.html()).appendTo($that);
+                        }
+                        if (settings.afterInsert && data) {
+                            settings.afterInsert(insertedElement, data);
                         }
                     }
                     done++;
@@ -228,13 +234,13 @@
             } else {
                 $(this).html($templateHtml);
             }
-            if (settings.afterInsert) {
+            if (settings.afterInsert && !isArray) {
                 settings.afterInsert($templateHtml, data);
             }
         });
 
         if (typeof settings.complete === "function") {
-            settings.complete.call($(this));
+            settings.complete.call($(this), data);
         }
     }
 


### PR DESCRIPTION
Added different handling of afterInsert event when data is an array.
When data is not an array event will be fired as before.

Should fix issue #75 which I was facing when populating a table from an array of objects.
In the afterInsert event I would set $.data for the <tr> but it was being set on the temporary object inside the <div>.
